### PR TITLE
ENH: add get_snapshot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort

--- a/archapp/__init__.py
+++ b/archapp/__init__.py
@@ -1,3 +1,8 @@
 from . import _version
+from .interactive import EpicsArchive
 
 __version__ = _version.get_versions()["version"]
+
+__all__ = [
+    "EpicsArchive",
+]

--- a/archapp/config.py
+++ b/archapp/config.py
@@ -1,6 +1,8 @@
 """
 config.py defines default archive appliance server properties
 """
-hostname = "pscaa02"
-data_port = 17668
-mgmt_port = 17665
+import os
+
+hostname = os.environ.get("ARCHAPP_HOSTNAME", "pscaa02")
+data_port = int(os.environ.get("ARCHAPP_DATA_PORT", 17668))
+mgmt_port = int(os.environ.get("ARCHAPP_MGMT_PORT", 17665))

--- a/archapp/data.py
+++ b/archapp/data.py
@@ -145,6 +145,7 @@ class ArchiveData(object):
             # '["pv1", "pv2"]'
             data=json.dumps(list(pvs)).encode("utf-8"),
         )
+        request.add_header("Content-Type", "application/json")
         response = urllib.request.urlopen(request)
         if check_error(response):
             return {}

--- a/archapp/data.py
+++ b/archapp/data.py
@@ -110,7 +110,7 @@ class ArchiveData(object):
         for pv in pvs:
             arrays.append(self.get(pv, start, end, chunk=chunk))
         if merge:
-            return xr.merge(arrays)
+            return xr.merge([arr for arr in arrays if arr.shape])
         return arrays
 
     def get_snapshot(
@@ -184,8 +184,14 @@ def make_xarray(data):
     #   - put 2d points with val, sevr, stat at timestamps
     #   - use meta to set array attributes
     #   - use most recent EGU PREC DESC, etc. to update meta values
-    points = data["data"]
-    meta = data["meta"]
+    try:
+        points = data["data"]
+        meta = data["meta"]
+    except KeyError:
+        # The appliance can return an empty dictionary. Return an empty xarray
+        # in that scenario.
+        return xr.DataArray()
+
     n_pts = len(points)
 
     # Allocate arrays

--- a/archapp/data.py
+++ b/archapp/data.py
@@ -1,23 +1,24 @@
 """
 data.py defines how to extract data from the archive appliance
 """
+import json
+import urllib
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from typing import Any, Dict, List
+
 import numpy as np
 import xarray as xr
 
 from . import config
 from .dates import utc_delta
 from .doc_sub import doc_sub
-from .url import (
-    PV_ARG,
-    URL_ARG,
-    URL_FLAG,
-    arch_url,
-    data_port_doc,
-    get_json,
-    hostname_doc,
-)
+from .url import (PV_ARG, URL_ARG, URL_FLAG, arch_url, check_error,
+                  data_port_doc, get_json, hostname_doc)
 
 GET_URL = "/retrieval/data/getData.json"
+GET_SNAPSHOT_URL = "/retrieval/data/getDataAtTime"
 
 url_args = """
 pvs : string or list of string
@@ -84,6 +85,7 @@ class ArchiveData(object):
         {data_port}
         """
         self.base_url = arch_url(hostname, data_port, GET_URL)
+        self.snapshot_url = arch_url(hostname, data_port, GET_SNAPSHOT_URL)
 
     @doc_sub(args=url_args, xarray=xarray_doc)
     def get(self, pvs, start, end, chunk=False, merge=True):
@@ -104,14 +106,49 @@ class ArchiveData(object):
         if isinstance(pvs, str):
             data = self.get_raw(pvs, start, end, chunk=chunk)
             return make_xarray(data)
-        else:
-            arrays = []
-            for pv in pvs:
-                arrays.append(self.get(pv, start, end, chunk=chunk))
-            if merge:
-                return xr.merge(arrays)
-            else:
-                return arrays
+        arrays = []
+        for pv in pvs:
+            arrays.append(self.get(pv, start, end, chunk=chunk))
+        if merge:
+            return xr.merge(arrays)
+        return arrays
+
+    def get_snapshot(
+        self,
+        pvs: List[str],
+        at: datetime,
+        include_proxies: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Parameters
+        ----------
+        pvs: list of str
+        at: datetime.datetime
+
+        Returns
+        -------
+        snapshot : dict of str to state
+            Where state is {...}
+        """
+        params = {
+            "at": date_spec(at),
+            "includeProxies": "true" if include_proxies else "false",
+        }
+        url_params = urllib.parse.urlencode(params)
+        if any('"' in pv for pv in pvs):
+            # Is it possible to escape these?
+            raise ValueError(f"PVs may not contain quotes: {pvs}")
+
+        request = urllib.request.Request(
+            url=f"{self.snapshot_url}?{url_params}",
+            # POST data should be something like:
+            # '["pv1", "pv2"]'
+            data=json.dumps(list(pvs)).encode("utf-8"),
+        )
+        response = urllib.request.urlopen(request)
+        if check_error(response):
+            return {}
+        return json.load(response)
 
     @doc_sub(args=url_args, raw=raw_doc)
     def get_raw(self, pv, start, end, chunk=False):

--- a/archapp/interactive.py
+++ b/archapp/interactive.py
@@ -4,6 +4,7 @@ interactive.py defines ipython archive interface
 
 import datetime as dt
 from datetime import datetime
+from typing import Any, Dict
 
 import numpy as np
 
@@ -85,7 +86,8 @@ class EpicsArchive(object):
         Methods
         -------
         get
-            Return timeseries data from the archiver as an xarray or numpy array.
+            Return timeseries data from the archiver as an xarray or numpy
+            array.
 
         plot
             Plot timeseries data from the archiver in a new figure.
@@ -114,7 +116,8 @@ class EpicsArchive(object):
 
     @doc_sub(args=interactive_args)
     def get(
-        self, pvname=None, start=30, end=None, unit="days", chunk=False, xarray=False
+        self, pvname=None, start=30, end=None, unit="days", chunk=False,
+        xarray=False
     ):
         """
         Return timeseries data from the archiver.
@@ -134,7 +137,8 @@ class EpicsArchive(object):
             pvname = self._last_pvname
             if pvname is None:
                 raise ValueError(
-                    "No cached pvname. Must provide the " "first pvname of the session."
+                    "No cached pvname. Must provide the first pvname of "
+                    "the session."
                 )
         else:
             self._last_pvname = pvname
@@ -151,22 +155,44 @@ class EpicsArchive(object):
                 values.append(xarr[var].values[0])
         return np.column_stack(values)
 
+    def get_snapshot(
+        self,
+        *pvs: str,
+        at: datetime,
+        include_proxies: bool = True
+    ) -> Dict[str, Any]:
+        pvs = sum((self._expand_pvnames(pv) for pv in pvs), [])
+        if not pvs:
+            raise ValueError(
+                "Expected one or more PVs, or glob pattern did not match PVs "
+                "in archiver."
+            )
+        return self._data.get_snapshot(
+            pvs=pvs, at=at, include_proxies=include_proxies
+        )
+
     def _expand_pvnames(self, pvname):
         """
         Given globs or list of globs, expand to the full set of pvs to look up
+
+        Parameters
+        ----------
+        pvname : str, list/tuple of str
         """
         if isinstance(pvname, str):
-            return self.search(pvname, do_print=False)
-        elif isinstance(pvname, (list, tuple)):
+            if "*" in pvname or "?" in pvname:
+                return self.search(pvname, do_print=False)
+            return [pvname]
+        if isinstance(pvname, (list, tuple)):
             pvs = []
             for pv in pvname:
                 pvs.extend(self._expand_pvnames(pv))
             return pvs
-        else:
-            raise Exception("pvname must be string, list, or tuple")
+        raise Exception("pvname must be string, list, or tuple")
 
     @doc_sub(args=interactive_args)
-    def prints(self, pvname=None, start=30, end=None, unit="days", chunk=False):
+    def prints(self, pvname=None, start=30, end=None, unit="days",
+               chunk=False):
         """
         Print timeseries data from the archiver.
 
@@ -175,7 +201,8 @@ class EpicsArchive(object):
         {args}
         """
         xarr = self.get(
-            pvname=pvname, start=start, end=end, unit=unit, chunk=chunk, xarray=True
+            pvname=pvname, start=start, end=end, unit=unit, chunk=chunk,
+            xarray=True
         )
         print_xarray(xarr, "vals")
 
@@ -195,17 +222,19 @@ class EpicsArchive(object):
         import matplotlib.pyplot as plt
 
         xarr = self.get(
-            pvname=pvname, start=start, end=end, unit=unit, chunk=chunk, xarray=True
+            pvname=pvname, start=start, end=end, unit=unit, chunk=chunk,
+            xarray=True
         )
         # print (xarr)
         df = xarr.to_dataframe()
         # return df
         values = df[pvname]["vals"]
-        sevrs = df[pvname]["sevr"]
+        # sevrs = df[pvname]["sevr"]
         # return values
         dft = xarr["time"].to_dataframe()["time"]
         # return xarr.to_dataframe()
-        # return xarr# DOING test_plot = arch.plot("pvname") --> test_plot.to_dataframe yeilds the same Pandas dataframe!
+        # return xarr# DOING test_plot = arch.plot("pvname")
+        # --> test_plot.to_dataframe yeilds the same Pandas dataframe!
 
         # plt.plot(sevrs, values)
         # plt.scatter(sevrs, values)
@@ -258,15 +287,9 @@ def convert_date_arg(arg, unit):
     date : datetime
     """
     if isinstance(arg, (list, tuple)):
-        try:
-            return dt.datetime(*arg)
-        except:
-            raise
+        return dt.datetime(*arg)
     elif not isinstance(arg, dt.datetime):
-        try:
-            days = days_map[unit] * float(arg)
-        except:
-            raise
+        days = days_map[unit] * float(arg)
         delta = dt.timedelta(days)
         return dt.datetime.now() - delta
     return arg

--- a/archapp/interactive.py
+++ b/archapp/interactive.py
@@ -161,6 +161,20 @@ class EpicsArchive(object):
         at: datetime,
         include_proxies: bool = True
     ) -> Dict[str, Any]:
+        """
+        Get a snapshot of PV data for the given PVs at the provided time.
+
+        Parameters
+        ----------
+        *pvs : str
+            The list of PV names.
+
+        at : datetime.datetime
+            The timestamp of the snapshot to request.
+
+        include_proxies : bool, optional
+            Allow the archiver appliance to use its internal proxies.
+        """
         pvs = sum((self._expand_pvnames(pv) for pv in pvs), [])
         if not pvs:
             raise ValueError(

--- a/archapp/tests/test_url.py
+++ b/archapp/tests/test_url.py
@@ -1,22 +1,24 @@
 import unittest
 
 from archapp import url as url_utils
+from archapp.config import data_port, hostname
 
-sample_good_url = "http://pscaa02:17668/retrieval/data/getData.json?pv=XPP:USR:MMS:01&from=2016-11-11T20:23:03.000Z&to=2016-11-11T20:24:03.000Z&donotchunk"
+sample_good_url = f"http://{hostname}:{data_port}/retrieval/data/getData.json?pv=XPP:USR:MMS:01&from=2016-11-11T20:23:03.000Z&to=2016-11-11T20:24:03.000Z&donotchunk"  # noqa
 
 sample_404 = sample_good_url.replace("XPP", "asdfebk")
 
-sample_no_connect = "http://xpp-monitor:17668/retrieval/data/getData.json?pv=XPP:USR:MMS:01&from=2016-11-11T20:23:03.000Z&to=2016-11-11T20:24:03.000Z&donotchunk"
+sample_no_connect = "http://xpp-monitor:17668/retrieval/data/getData.json?pv=XPP:USR:MMS:01&from=2016-11-11T20:23:03.000Z&to=2016-11-11T20:24:03.000Z&donotchunk"  # noqa
 
 
 class UrlJsonCase(unittest.TestCase):
     def test_url_basic_quote(self):
         url = url_utils.url_quote(sample_good_url)
-        expected = "http://pscaa02:17668/retrieval/data/getData.json?pv=XPP%3AUSR%3AMMS%3A01&from=2016-11-11T20%3A23%3A03.000Z&to=2016-11-11T20%3A24%3A03.000Z&donotchunk"
+        expected = f"http://{hostname}:{data_port}/retrieval/data/getData.json?pv=XPP%3AUSR%3AMMS%3A01&from=2016-11-11T20%3A23%3A03.000Z&to=2016-11-11T20%3A24%3A03.000Z&donotchunk"  # noqa
         self.assertEqual(
             url,
             expected,
-            "Not quoting reserved characters properly. Expected {0} but got {1}".format(
+            "Not quoting reserved characters properly."
+            "Expected {0} but got {1}".format(
                 expected, url
             ),
         )
@@ -24,7 +26,8 @@ class UrlJsonCase(unittest.TestCase):
     def test_url_normal_get(self):
         data = url_utils.get_json(sample_good_url)
         self.assertIsInstance(
-            data, dict, "Did not get a dictionary! Got {} instead!".format(type(data))
+            data, dict,
+            "Did not get a dictionary! Got {} instead!".format(type(data))
         )
         self.assertTrue(data, "No data! {}".format(data))
 

--- a/archapp/url.py
+++ b/archapp/url.py
@@ -71,8 +71,8 @@ def get_json(url, timeout=1):
     signal.alarm(timeout)
     try:
         http = urllib.request.urlopen(url)
-    except (UrlTimeout, IOError):
-        print("No connection to archiver.")
+    except (UrlTimeout, IOError) as ex:
+        print(f"No connection to archiver. ({url} resulted in {ex})")
         return {}
     finally:
         signal.alarm(0)

--- a/archapp/url.py
+++ b/archapp/url.py
@@ -9,7 +9,7 @@ import urllib.request
 
 try:
     import simplejson as json
-except:
+except ImportError:
     import json
 from .doc_sub import doc_sub
 
@@ -72,7 +72,7 @@ def get_json(url, timeout=1):
     try:
         http = urllib.request.urlopen(url)
     except (UrlTimeout, IOError):
-        print("No conection to archiver.")
+        print("No connection to archiver.")
         return {}
     finally:
         signal.alarm(0)
@@ -82,8 +82,7 @@ def get_json(url, timeout=1):
     http.close()
     if isinstance(data, list) and len(data) == 1 and isinstance(data[0], dict):
         return data[0]
-    else:
-        return data
+    return data
 
 
 def url_quote(url):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-import versioneer
 from setuptools import find_packages, setup
 
-import archapp
+import versioneer
 
 with open("requirements.txt", "rt") as fp:
     install_requires = [


### PR DESCRIPTION
Add `get_snapshot` tool to get PV data (one or more PVs or globs) at a given point in time.

* Added pre-commit config
* Started `get_snapshot` utility for getting values of multiple PVs at a specific point in time (referred to as save/restore API in the docs)
* Cleaned up some flake8 issues (sorry for the mess)
* To investigate: skipped `search()` to pattern match via globs if no glob characters were included. Ensure this doesn't mess up any current functionality.

WIP until Murali gets around to adding metadata to the snapshot data, which is estimated to be live next month.