### PR TITLE
Updating hostname and increasing search_pvs timeout

### DIFF
--- a/archapp/config.py
+++ b/archapp/config.py
@@ -3,6 +3,6 @@ config.py defines default archive appliance server properties
 """
 import os
 
-hostname = os.environ.get("ARCHAPP_HOSTNAME", "pscaa02")
+hostname = os.environ.get("ARCHAPP_HOSTNAME", "pscaa01")
 data_port = int(os.environ.get("ARCHAPP_DATA_PORT", 17668))
 mgmt_port = int(os.environ.get("ARCHAPP_MGMT_PORT", 17665))

--- a/archapp/mgmt.py
+++ b/archapp/mgmt.py
@@ -47,7 +47,7 @@ class ArchiveMgmt(object):
         url += PV_ARG.format(glob)
         # Increase timeout on search calls because they take approx 5-6 secs
         # Call time is mostly independent of which glob we use
-        pvs = get_json(url, timeout=10)
+        pvs = get_json(url, timeout=20)
         if not pvs:
             pvs = []
         if do_print:


### PR DESCRIPTION
```
(pcds-5.9.1) [kaushikm@psbuild-rhel7-03 archapp]$ pytest -v tests/
/cds/group/pcds/pyps/conda/py39/envs/pcds-5.9.1/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
==================================================== test session starts ====================================================
platform linux -- Python 3.9.19, pytest-8.3.3, pluggy-1.5.0 -- /cds/group/pcds/pyps/conda/py39/envs/pcds-5.9.1/bin/python3.9
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /cds/home/k/kaushikm/archapp
plugins: jaxtyping-0.2.33, benchmark-4.0.0, repeat-0.9.2, xdist-3.6.1, typeguard-2.13.3, asyncio-0.24.0, anyio-4.4.0, qt-4.4.0, timeout-2.3.1, cov-5.0.0
asyncio: mode=strict, default_loop_scope=None
collected 19 items

tests/test_data.py::ArchiveDataFuncTestCase::test_date_spec PASSED                                                    [  5%]
tests/test_data.py::ArchiveDataFuncTestCase::test_make_url PASSED                                                     [ 10%]
tests/test_data.py::ArchiveDataFuncTestCase::test_make_xarray PASSED                                                  [ 15%]
tests/test_data.py::ArchiveDataClassTestCase::test_get PASSED                                                         [ 21%]
tests/test_data.py::ArchiveDataClassTestCase::test_get_raw PASSED                                                     [ 26%]
tests/test_dates.py::DatesTestCase::test_utc_delta_sanity PASSED                                                      [ 31%]
tests/test_dates.py::DatesTestCase::test_utc_delta_type PASSED                                                        [ 36%]
tests/test_doc_sub.py::DocSubTestCase::test_doc_sub_basic PASSED                                                      [ 42%]
tests/test_mgmt.py::ArchiveMgmtTestCase::test_search_bad_pv PASSED                                                    [ 47%]
tests/test_mgmt.py::ArchiveMgmtTestCase::test_search_print_no_crash PASSED                                            [ 52%]
tests/test_mgmt.py::ArchiveMgmtTestCase::test_search_pv PASSED                                                        [ 57%]
tests/test_mgmt.py::ArchiveMgmtBadTestCase::test_search_bad_hostname PASSED                                           [ 63%]
tests/test_mgmt.py::ArchiveMgmtBadTestCase::test_search_bad_port PASSED                                               [ 68%]
tests/test_print_formats.py::test_print_list_no_crash PASSED                                                          [ 73%]
tests/test_url.py::UrlJsonCase::test_url_bad_pv PASSED                                                                [ 78%]
tests/test_url.py::UrlJsonCase::test_url_base PASSED                                                                  [ 84%]
tests/test_url.py::UrlJsonCase::test_url_basic_quote PASSED                                                           [ 89%]
tests/test_url.py::UrlJsonCase::test_url_no_connect PASSED                                                            [ 94%]
tests/test_url.py::UrlJsonCase::test_url_normal_get PASSED                                                            [100%]

==================================================== 19 passed in 19.77s ====================================================
```
```
(pcds-5.9.1) [kaushikm@psbuild-rhel7-03 archapp]$ python
Python 3.9.19 | packaged by conda-forge | (main, Mar 20 2024, 12:50:21)
[GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from archapp.interactive import EpicsArchive
^[[A
KeyboardInterrupt
>>> arch = EpicsArchive()
>>> arch.get("QRIXS:DET:GCC:01:PRESS_RBV", xarray=True)
<xarray.Dataset> Size: 68MB
Dimensions:                     (field: 3, time: 2132787)
Coordinates:
  * field                       (field) <U4 48B 'vals' 'sevr' 'stat'
  * time                        (time) datetime64[ns] 17MB 2025-03-04T23:00:1...
Data variables:
    QRIXS:DET:GCC:01:PRESS_RBV  (field, time) object 51MB 1.2811752769792406e...
Attributes:
    name:     QRIXS:DET:GCC:01:PRESS_RBV
    EGU:      TORR
    PREC:     2
    HIGH:     0.0
    HIHI:     0.0
    LOLO:     0.0
    LOW:      0.0
    LOPR:     0.0
    HOPR:     1000.0
    DESC:     GVL_SA.qRIXS_DET_GCC_01.IG.rPRESS
```
Had to increase the timeout to pass test_search_pv. Could just be slower because I did it off-site but I don't think increasing it hurts, wget took around fifteen seconds. Incidentally, ArchiveMgmt.search_pvs seems to do exaclty what I was looking for, although it uses getAllPVs in the url and not getMatchingPVs